### PR TITLE
Fix deprecated raw_post_content

### DIFF
--- a/piston/utils.py
+++ b/piston/utils.py
@@ -234,7 +234,7 @@ class Mimer(object):
 
             if loadee:
                 try:
-                    self.request.data = loadee(self.request.raw_post_data)
+                    self.request.data = loadee(self.request.body)
 
                     # Reset both POST and PUT from request, as its
                     # misleading having their presence around.

--- a/piston/utils.py
+++ b/piston/utils.py
@@ -1,8 +1,6 @@
 import time
 
-import django
-from django.http import HttpResponseNotAllowed, HttpResponseForbidden, HttpResponse, HttpResponseBadRequest
-from django.core.urlresolvers import reverse
+from django.http import HttpResponse
 from django.core.cache import cache
 from django import get_version as django_version
 from django.core.mail import send_mail, mail_admins
@@ -11,8 +9,6 @@ from django.utils.translation import ugettext as _
 from django.template import loader, TemplateDoesNotExist
 from django.contrib.sites.models import Site
 from decorator import decorator
-
-from datetime import datetime, timedelta
 
 __version__ = '0.2.3rc1'
 


### PR DESCRIPTION
I believe this will fix:
https://sentry.io/organizations/arm/issues/1114872143/?environment=production&project=1403193

What I don't understand is why that error has only just started happening. `WSGIRequest->raw_post_content` was deprecated in Django 1.6, which we migrated away from _years_ ago. Either way, `request.body` is the replacement method.