### PR TITLE
Remove namespace_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     author = 'Jesper Noehr',
     author_email = 'jesper@noehr.org',
     packages = find_packages(),
-    namespace_packages = ['piston'],
     include_package_data = True,
     zip_safe = False,
     classifiers = [


### PR DESCRIPTION
Remove `namespace_packages` setting from setup.py as it is not needed, and it is playing havoc with my tox setup on os.mbed.com