### PR TITLE
Use `smart_text` instead of `smart_unicode`

### DIFF
--- a/piston/emitters.py
+++ b/piston/emitters.py
@@ -29,7 +29,7 @@ except ImportError:
     from django.utils import simplejson
 
 from django.utils.xmlutils import SimplerXMLGenerator
-from django.utils.encoding import smart_unicode
+from django.utils.encoding import smart_text
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse
@@ -96,7 +96,7 @@ class Emitter(object):
         """
         Recursively serialize a lot of types, and
         in cases where it doesn't recognize the type,
-        it will fall back to Django's `smart_unicode`.
+        it will fall back to Django's `smart_text`.
 
         Returns `dict`.
         """
@@ -137,7 +137,7 @@ class Emitter(object):
             elif repr(thing).startswith("<django.db.models.fields.related.RelatedManager"):
                 ret = _any(thing.all())
             else:
-                ret = smart_unicode(thing, strings_only=True)
+                ret = smart_text(thing, strings_only=True)
 
             self.stack.pop()
 
@@ -386,7 +386,7 @@ class XMLEmitter(Emitter):
                 self._to_xml(xml, value)
                 xml.endElement(key)
         else:
-            xml.characters(smart_unicode(data))
+            xml.characters(smart_text(data))
 
     def render(self, request):
         stream = StringIO.StringIO()


### PR DESCRIPTION
`smart_unicode` is only available in python2

https://docs.djangoproject.com/en/1.11/ref/utils#django.utils.encoding.smart_unicode